### PR TITLE
Use https api endpoint instead of http

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const dateUtil = require('./dateUtil')
 const port = process.env.PORT || 5000
 const startMsg = '\033[33mServer started in \033[36mhttp://localhost:' + port + ', \033[33mtook \033[39m'
 const startedTime = new Date().toString()
-const baseUrl = 'http://v2.tableonline.fi/instabook/bookings'
+const baseUrl = 'https://v2.tableonline.fi/instabook/bookings'
 const urlForDate = `${baseUrl}/availabilities/t7c5hxB/589/2?locale=fi&date=`
 console.time(startMsg)
 http.createServer((req, res) => {


### PR DESCRIPTION
Retrieving tables failing now because the code can't handle the redirect. Fixed this with retrieving info from the api with https instead of http.